### PR TITLE
Andere Beschreibung der Open Data Directive

### DIFF
--- a/Vorschlag.md
+++ b/Vorschlag.md
@@ -4,7 +4,7 @@ Im Rahmen der Open Government Umsetzungsstrategie des Bundes wurde beschlossen, 
 **Um diesen Veränderungsprozess transparent zu machen, soll ein 5-Punkte-Plan beschlossen werden:**
 
 1. Dokumentation und Zugänglichmachung aller bestehenden Schnittstellen des Bundes bis Ende 2021.
-2. Bereitstellung aller Basisdatensätze aus den Themenfeldern Geobasisdaten, Wetterdaten, Statistiken, Handels- und Transparenzregister und Mobilität entsprechend der EU-Direktive 2019/1024 als Open Data bis Q3 2022.
+2. Bereitstellung aller Basisdatensätze aus den Themenfeldern Geobasisdaten, Wetterdaten, Statistiken, Handels- und Transparenzregister und Mobilität entsprechend der EU-Richtlinie 2019/1024 (Open Data Directive) als Open Data bis Q3 2022.
 3. Ergänzung aller Leistungen des Onlinezugangsgesetzes um Programmierschnittstellen bis 2023.
 4. Umstellung auf Open Development Prozess in allen IT-Projekten des Bundes bis 2024.
 5. Ausweitung von Förderung der digitalen Zivilgesellschaft im Rahmen von unabhängigen Förderprogrammen über die neu zu gründende Verbrauchsstiftung Open Data.


### PR DESCRIPTION
+ Direktive ist in Deutschland ein eher seltenes Synonym für Richtlinie (EU), wird aber nicht komplett aus dem Satz genommen
- Sorgt leider für zweimal "Open Data" in geringer Distanz, dafür